### PR TITLE
New API endpoint for report as plain Java object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.tum.in.ase</groupId>
   <artifactId>static-code-analysis-parser</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Static Code Analysis Report Parser</name>

--- a/src/main/java/de/tum/in/ase/parser/ReportParser.java
+++ b/src/main/java/de/tum/in/ase/parser/ReportParser.java
@@ -37,4 +37,23 @@ public class ReportParser {
             throw new ParserException(e.getMessage(), e);
         }
     }
+
+    /**
+     * Transform a given static code analysis report into a plain Java object.
+     *
+     * @param file Reference to the static code analysis report
+     * @return Static code analysis report represented as a plain Java object
+     * @throws ParserException - If any error occurs parsing the report
+     */
+    public Report transformToReport(File file) throws ParserException {
+        try {
+            if (file == null) {
+                throw new IllegalArgumentException("File must not be null");
+            }
+            return context.getReport(file);
+        }
+        catch (Exception e) {
+            throw new ParserException(e.getMessage(), e);
+        }
+    }
 }


### PR DESCRIPTION
Adds a new API endpoint for getting the parsed report as a plain Java object. This is required as the Jenkins plugin uses GSON to convert the model into JSON. 