### PR TITLE
Add full path to Spotbugs issues

### DIFF
--- a/src/main/java/de/tum/in/ase/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/SpotbugsParser.java
@@ -1,7 +1,9 @@
 package de.tum.in.ase.parser.strategy;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import nu.xom.Document;
 import nu.xom.Element;
@@ -30,10 +32,16 @@ class SpotbugsParser implements ParserStrategy {
         // Element BugCollection
         Element root = doc.getRootElement();
 
-        String sourceDirectory = root.getFirstChildElement(PROJECT_ELEMENT).getFirstChildElement(SOURCE_DIRECTORY_ELEMENT).getValue();
-        if (!sourceDirectory.endsWith("/")) {
-            sourceDirectory += "/";
-        }
+        String sourceDirectory = Optional.ofNullable(root.getFirstChildElement(PROJECT_ELEMENT))
+                .flatMap(p -> Optional.ofNullable(p.getFirstChildElement(SOURCE_DIRECTORY_ELEMENT)))
+                .map(Element::getValue)
+                .map(srcDir -> {
+                    if (!srcDir.endsWith(File.separator)) {
+                        return srcDir + File.separator;
+                    } else {
+                        return srcDir;
+                    }
+                }).orElse("");
 
         // Iterate over <BugInstance> elements
         for (Element bugInstance : root.getChildElements(BUGINSTANCE_ELEMENT)) {

--- a/src/main/java/de/tum/in/ase/parser/strategy/SpotbugsParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/SpotbugsParser.java
@@ -12,6 +12,8 @@ import de.tum.in.ase.parser.domain.Report;
 
 class SpotbugsParser implements ParserStrategy {
 
+    private static final String PROJECT_ELEMENT = "Project";
+    private static final String SOURCE_DIRECTORY_ELEMENT = "SrcDir";
     private static final String BUGINSTANCE_ELEMENT = "BugInstance";
     private static final String BUGINSTANCE_ATT_TYPE = "type";
     private static final String BUGINSTANCE_ATT_CATEGORY = "category";
@@ -28,6 +30,11 @@ class SpotbugsParser implements ParserStrategy {
         // Element BugCollection
         Element root = doc.getRootElement();
 
+        String sourceDirectory = root.getFirstChildElement(PROJECT_ELEMENT).getFirstChildElement(SOURCE_DIRECTORY_ELEMENT).getValue();
+        if (!sourceDirectory.endsWith("/")) {
+            sourceDirectory += "/";
+        }
+
         // Iterate over <BugInstance> elements
         for (Element bugInstance : root.getChildElements(BUGINSTANCE_ELEMENT)) {
             Issue issue = new Issue();
@@ -41,8 +48,7 @@ class SpotbugsParser implements ParserStrategy {
             Elements sourceLines = bugInstance.getChildElements(SOURCELINE_ELEMENT);
             if (sourceLines.size() > 0) {
                 Element sourceLine = sourceLines.get(0);
-                // The sourcePath begins with the package name so we don't need to shorten it
-                String unixPath = ParserUtils.transformToUnixPath(sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH));
+                String unixPath = ParserUtils.transformToUnixPath(sourceDirectory + sourceLine.getAttributeValue(SOURCELINE_ATT_SOURCEPATH));
                 issue.setFilePath(unixPath);
                 // Set endLine by duplicating the startLine. Spotbugs does not support a endLine
                 int startLine = ParserUtils.extractInt(sourceLine, SOURCELINE_ATT_START);


### PR DESCRIPTION
# Motivation
Spotbugs does not include the full path of issues. This results in those issues not being shown in the Artemis online code editor as annotations because they cannot be matched to an existing file.
The full path should be added here to match the behaviour of the other tools. Artemis removes CI-specific parts of the path anyway: https://github.com/ls1intum/Artemis/blob/7fedc21f84e2934e7b78ef837cb2fd02561f83f7/src/main/java/de/tum/in/www1/artemis/service/FeedbackService.java#L85

# Screenshots of Artemis before this PR
Issue correctly shown in issue list (missing `src/` part of the path in the first line):
![Screenshot_20201105_122434](https://user-images.githubusercontent.com/64250573/98238663-07547480-1f67-11eb-858c-b3d526acdaa6.png)
Issue not shown as annotation in code editor:
![Screenshot_20201105_122501](https://user-images.githubusercontent.com/64250573/98238670-091e3800-1f67-11eb-89a6-059a51576522.png)
