### PR TITLE
Add Parser for SwiftLint 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.tum.in.ase</groupId>
   <artifactId>static-code-analysis-parser</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <packaging>jar</packaging>
 
   <name>Static Code Analysis Report Parser</name>

--- a/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
@@ -1,0 +1,66 @@
+package de.tum.in.ase.parser.strategy;
+
+import de.tum.in.ase.parser.domain.Issue;
+import de.tum.in.ase.parser.domain.Report;
+import nu.xom.Document;
+import nu.xom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class CheckstyleFormatParser implements ParserStrategy {
+
+    static final String FILE_TAG = "file";
+    static final String FILE_ATT_NAME = "name";
+    static final String ERROR_ATT_SOURCE = "source";
+    static final String ERROR_ATT_SEVERITY = "severity";
+    static final String ERROR_ATT_MESSAGE = "message";
+    static final String ERROR_ATT_LINENUMBER = "line";
+    static final String ERROR_ATT_COLUMN = "column";
+
+    // The packages rooted at checks denote the category and rule
+    static final String CATEGORY_DELIMITER = "checks";
+    // Some rules don't belong to a category. We group them under this identifier.
+    static final String CATEGORY_MISCELLANEOUS = "miscellaneous";
+
+    protected static String getProgrammingLanguage(String path) {
+        String extension = path.substring(path.lastIndexOf("."));
+        return extension.substring(1);
+    }
+
+    protected void extractIssues(Document doc, Report report) {
+        List<Issue> issues = new ArrayList<>();
+        Element root = doc.getRootElement();
+
+        // Iterate over all <file> elements
+        for (Element fileElement : root.getChildElements(FILE_TAG)) {
+            String unixPath = ParserUtils.transformToUnixPath(fileElement.getAttributeValue(FILE_ATT_NAME));
+
+            // Iterate over all <error> elements
+            for (Element errorElement : fileElement.getChildElements()) {
+                Issue issue = new Issue(unixPath);
+
+                String errorSource = errorElement.getAttributeValue(ERROR_ATT_SOURCE);
+                extractRuleAndCategory(issue, errorSource);
+
+                issue.setPriority(errorElement.getAttributeValue(ERROR_ATT_SEVERITY));
+                issue.setMessage(errorElement.getAttributeValue(ERROR_ATT_MESSAGE));
+
+                // Set startLine as endLine as Checkstyle does not support an end line
+                int startLine = ParserUtils.extractInt(errorElement, ERROR_ATT_LINENUMBER);
+                issue.setStartLine(startLine);
+                issue.setEndLine(startLine);
+
+                // Set startColumn as endColumn as Checkstyle does not support an end column
+                int startColumn = ParserUtils.extractInt(errorElement, ERROR_ATT_COLUMN);
+                issue.setStartColumn(startColumn);
+                issue.setEndColumn(startColumn);
+
+                issues.add(issue);
+            }
+        }
+        report.setIssues(issues);
+    }
+
+    abstract void extractRuleAndCategory(Issue issue, String errorSource);
+}

--- a/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
@@ -11,18 +11,18 @@ import de.tum.in.ase.parser.domain.Report;
 
 public abstract class CheckstyleFormatParser implements ParserStrategy {
 
-    static final String FILE_TAG = "file";
-    static final String FILE_ATT_NAME = "name";
-    static final String ERROR_ATT_SOURCE = "source";
-    static final String ERROR_ATT_SEVERITY = "severity";
-    static final String ERROR_ATT_MESSAGE = "message";
-    static final String ERROR_ATT_LINENUMBER = "line";
-    static final String ERROR_ATT_COLUMN = "column";
+    protected static final String FILE_TAG = "file";
+    protected static final String FILE_ATT_NAME = "name";
+    protected static final String ERROR_ATT_SOURCE = "source";
+    protected static final String ERROR_ATT_SEVERITY = "severity";
+    protected static final String ERROR_ATT_MESSAGE = "message";
+    protected static final String ERROR_ATT_LINENUMBER = "line";
+    protected static final String ERROR_ATT_COLUMN = "column";
 
     // The packages rooted at checks denote the category and rule
-    static final String CATEGORY_DELIMITER = "checks";
+    protected static final String CATEGORY_DELIMITER = "checks";
     // Some rules don't belong to a category. We group them under this identifier.
-    static final String CATEGORY_MISCELLANEOUS = "miscellaneous";
+    protected static final String CATEGORY_MISCELLANEOUS = "miscellaneous";
 
     protected static String getProgrammingLanguage(String path) {
         String extension = path.substring(path.lastIndexOf("."));
@@ -63,5 +63,5 @@ public abstract class CheckstyleFormatParser implements ParserStrategy {
         report.setIssues(issues);
     }
 
-    abstract void extractRuleAndCategory(Issue issue, String errorSource);
+    protected abstract void extractRuleAndCategory(Issue issue, String errorSource);
 }

--- a/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
@@ -19,11 +19,6 @@ public abstract class CheckstyleFormatParser implements ParserStrategy {
     protected static final String ERROR_ATT_LINENUMBER = "line";
     protected static final String ERROR_ATT_COLUMN = "column";
 
-    // The packages rooted at checks denote the category and rule
-    protected static final String CATEGORY_DELIMITER = "checks";
-    // Some rules don't belong to a category. We group them under this identifier.
-    protected static final String CATEGORY_MISCELLANEOUS = "miscellaneous";
-
     protected static String getProgrammingLanguage(String path) {
         String extension = path.substring(path.lastIndexOf("."));
         return extension.substring(1);

--- a/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleFormatParser.java
@@ -1,12 +1,13 @@
 package de.tum.in.ase.parser.strategy;
 
-import de.tum.in.ase.parser.domain.Issue;
-import de.tum.in.ase.parser.domain.Report;
+import java.util.ArrayList;
+import java.util.List;
+
 import nu.xom.Document;
 import nu.xom.Element;
 
-import java.util.ArrayList;
-import java.util.List;
+import de.tum.in.ase.parser.domain.Issue;
+import de.tum.in.ase.parser.domain.Report;
 
 public abstract class CheckstyleFormatParser implements ParserStrategy {
 

--- a/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/CheckstyleParser.java
@@ -7,6 +7,11 @@ import de.tum.in.ase.parser.domain.Report;
 
 class CheckstyleParser extends CheckstyleFormatParser {
 
+    // The packages rooted at checks denote the category and rule
+    private static final String CATEGORY_DELIMITER = "checks";
+    // Some rules don't belong to a category. We group them under this identifier.
+    private static final String CATEGORY_MISCELLANEOUS = "miscellaneous";
+
     public Report parse(Document doc) {
         Report report = new Report(StaticCodeAnalysisTool.CHECKSTYLE);
         extractIssues(doc, report);

--- a/src/main/java/de/tum/in/ase/parser/strategy/ParserPolicy.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/ParserPolicy.java
@@ -1,6 +1,8 @@
 package de.tum.in.ase.parser.strategy;
 
 import nu.xom.Document;
+import nu.xom.Element;
+import nu.xom.Elements;
 
 import de.tum.in.ase.parser.exception.UnsupportedToolException;
 
@@ -22,6 +24,37 @@ class ParserPolicy {
         String rootTag = document.getRootElement().getLocalName();
         StaticCodeAnalysisTool tool = StaticCodeAnalysisTool.getToolByIdentifierTag(rootTag)
                 .orElseThrow(() -> new UnsupportedToolException("Tool for identifying tag " + rootTag + " not found"));
-        context.setParserStrategy(tool.getStrategy());
+
+        if (tool.getIdentifyingTag().equals("checkstyle")) {
+            // Check for different checkstyle parsers
+            setCorrectCheckstyleParser(document);
+        } else {
+            context.setParserStrategy(tool.getStrategy());
+        }
+    }
+
+    /**
+     * Based on the reported files which are listed within the xml document, we search for the used programming language
+     * and set the parser accordingly
+     *
+     * @param document static code analysis xml report
+     */
+    private void setCorrectCheckstyleParser(Document document) {
+        Element root = document.getRootElement();
+        String language;
+        Elements fileElements = root.getChildElements(CheckstyleFormatParser.FILE_TAG);
+        if (fileElements.size() > 0) {
+            Element fileElement = fileElements.get(0);
+            String unixPath = ParserUtils.transformToUnixPath(fileElement.getAttributeValue(CheckstyleFormatParser.FILE_ATT_NAME));
+            language = CheckstyleFormatParser.getProgrammingLanguage(unixPath);
+            if (language.equals("swift")) {
+                context.setParserStrategy(StaticCodeAnalysisTool.SWIFTLINT.getStrategy());
+            } else {
+                context.setParserStrategy(StaticCodeAnalysisTool.CHECKSTYLE.getStrategy());
+            }
+        } else {
+            // default checkstyle tool
+            context.setParserStrategy(StaticCodeAnalysisTool.CHECKSTYLE.getStrategy());
+        }
     }
 }

--- a/src/main/java/de/tum/in/ase/parser/strategy/StaticCodeAnalysisTool.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/StaticCodeAnalysisTool.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 public enum StaticCodeAnalysisTool {
     SPOTBUGS("BugCollection", new SpotbugsParser()),
     CHECKSTYLE("checkstyle", new CheckstyleParser()),
+    SWIFTLINT("checkstyle", new SwiftLintParser()),
     PMD("pmd", new PMDParser()),
     PMD_CPD("pmd-cpd", new PMDCPDParser());
 

--- a/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
@@ -32,7 +32,7 @@ class SwiftLintParser extends CheckstyleFormatParser {
         }
 
         String rule = errorSourceSegments[noOfSegments - 1]; // e.g. trailing_semicolon
-        String category = errorSourceSegments[noOfSegments - 1].split("_")[0]; // e.g. trailing
+        String category = "swiftLint";
 
         issue.setRule(rule);
         issue.setCategory(category);

--- a/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
@@ -24,13 +24,6 @@ class SwiftLintParser extends CheckstyleFormatParser {
     protected void extractRuleAndCategory(Issue issue, String errorSource) {
         String[] errorSourceSegments = errorSource.split("\\.");
         int noOfSegments = errorSourceSegments.length;
-
-        // Should never happen but check for robustness
-        if (noOfSegments < 2) {
-            issue.setCategory(errorSource);
-            return;
-        }
-
         String rule = errorSourceSegments[noOfSegments - 1]; // e.g. trailing_semicolon
         String category = "swiftLint";
 

--- a/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
@@ -5,10 +5,11 @@ import nu.xom.Document;
 import de.tum.in.ase.parser.domain.Issue;
 import de.tum.in.ase.parser.domain.Report;
 
-class CheckstyleParser extends CheckstyleFormatParser {
+class SwiftLintParser extends CheckstyleFormatParser {
 
+    @Override
     public Report parse(Document doc) {
-        Report report = new Report(StaticCodeAnalysisTool.CHECKSTYLE);
+        Report report = new Report(StaticCodeAnalysisTool.SWIFTLINT);
         extractIssues(doc, report);
         return report;
     }
@@ -32,13 +33,10 @@ class CheckstyleParser extends CheckstyleFormatParser {
             issue.setCategory(errorSource);
             return;
         }
-        String rule = errorSourceSegments[noOfSegments - 1];
-        String category = errorSourceSegments[noOfSegments - 2];
 
-        // Check if the rule has a category
-        if (category.equals(CATEGORY_DELIMITER)) {
-            category = CATEGORY_MISCELLANEOUS;
-        }
+        String rule = errorSourceSegments[noOfSegments - 1]; // e.g. trailing_semicolon
+        String category = errorSourceSegments[noOfSegments - 1].split("_")[0]; // e.g. trailing
+
         issue.setRule(rule);
         issue.setCategory(category);
     }

--- a/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
+++ b/src/main/java/de/tum/in/ase/parser/strategy/SwiftLintParser.java
@@ -18,10 +18,7 @@ class SwiftLintParser extends CheckstyleFormatParser {
      * Extracts and sets the rule and the category given the check's package name.
      *
      * @param issue issue under construction
-     * @param errorSource package like com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck. The first
-     *                    segment after '.checks.' denotes the category and the segment after the rule. Some rules do
-     *                    not belong to a category e.g. com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.
-     *                    Such rule will be grouped under {@link #CATEGORY_MISCELLANEOUS}.
+     * @param errorSource package like swiftlint.rules.trailing_semicolon
      */
     @Override
     protected void extractRuleAndCategory(Issue issue, String errorSource) {


### PR DESCRIPTION
This adds a new parser for SwiftLint. 
The old CheckstyleParser now extends the CheckstyleFormatParser, which provides the necessary default functionality.
To distinguish which parser to use (Checkstyle for Java, SwiftLint for Swift) we check the file extension within the `<file name=".*(.java|.swift)">` tag of a checkstyle xml file. 